### PR TITLE
Add support for a video/3gpp format

### DIFF
--- a/lib/mime_sniff/default_signatures
+++ b/lib/mime_sniff/default_signatures
@@ -40,6 +40,8 @@ ExactSignature,4F 67 67 53 00,application/ogg
 ExactSignature,4D 54 68 64 00 00 00 06,audio/midi
 MaskedSignature,52 49 46 46 00 00 00 00 41 56 49 20,FF FF FF FF 00 00 00 00 FF FF FF FF,video/avi
 MaskedSignature,52 49 46 46 00 00 00 00 57 41 56 45,FF FF FF FF 00 00 00 00 FF FF FF FF,audio/wave
+# Matching 3GPP video
+MaskedSignature,00 00 00 00 66 74 79 70 33 67 70 34 00,00 00 00 00 FF FF FF FF FF FF FF FF FF,video/3gpp
 # 6.2.1 Matching a MP4 pattern https://mimesniff.spec.whatwg.org/#signature-for-mp4
 MP4Signature
 # 6.2.2 Matching a WebM pattern https://mimesniff.spec.whatwg.org/#signature-for-webm

--- a/test/mime_sniff/signatures_test.exs
+++ b/test/mime_sniff/signatures_test.exs
@@ -15,7 +15,7 @@ defmodule MimeSniff.SignaturesTest do
     test "return list of signature from default_signatures file" do
       default_signatures = Signatures.get_default_signatures()
 
-      assert length(default_signatures) == 49
+      assert length(default_signatures) == 50
 
       assert default_signatures == [
                %HTMLSignature{
@@ -160,6 +160,11 @@ defmodule MimeSniff.SignaturesTest do
                  mime_type: "audio/wave",
                  pattern_mask: <<255, 255, 255, 255, 0, 0, 0, 0, 255, 255, 255, 255>>
                },
+               %MaskedSignature{
+                byte_pattern: <<0x00, 0x00, 0x00, 0x00, 0x66, 0x74, 0x79, 0x70, 0x33, 0x67, 0x70, 0x34, 0x00>>,
+                mime_type: "video/3gpp",
+                pattern_mask: <<0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF>>
+              },
                %MP4Signature{},
                %ExactSignature{
                  byte_pattern: <<26, 69, 223, 163>>,


### PR DESCRIPTION
I know that the format is not specified by the MimeSniff standard, but I have encountered video/3gpp files from a relatively recent Android 10 phone.
As far as I can see, this shouldn't break anything.